### PR TITLE
bugfix(device_name): Fix KeyError when API doesn't return device name…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,19 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Home Assistant specific files
+.HA_VERSION
+.ha_run.lock
+.storage/
+automations.yaml
+blueprints/
+configuration.yaml
+home-assistant.log.1
+home-assistant.log.fault
+home-assistant_v2.db
+home-assistant_v2.db-shm
+home-assistant_v2.db-wal
+scenes.yaml
+scripts.yaml
+secrets.yaml

--- a/custom_components/appartme/__init__.py
+++ b/custom_components/appartme/__init__.py
@@ -115,12 +115,17 @@ async def async_setup_entry(hass, config_entry):
 
             devices_info.append(device_info)
 
+            # Get default device name from translations
+            default_device_name = get_translation(
+                translations, "device.default_name", "Main Module"
+            )
+            
             # Create a coordinator for this device
             coordinator = AppartmeDataUpdateCoordinator(
                 hass,
                 api,
                 device_id,
-                device_info.get("name", "Unknown Device"),
+                device_info.get("name", default_device_name),
                 update_interval=timedelta(seconds=update_interval),
             )
 

--- a/custom_components/appartme/climate.py
+++ b/custom_components/appartme/climate.py
@@ -42,10 +42,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             [
                 AppartmeThermostat(
                     api,
-                    device_info,
                     prop["propertyId"],
-                    translations,
                     coordinator,
+                    translations,
                 )
                 for prop in device_info.get("properties", [])
                 if prop["propertyId"] == "thermostat_mode"
@@ -63,12 +62,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class AppartmeThermostat(CoordinatorEntity, ClimateEntity):
     """Representation of an Appartme thermostat."""
 
-    def __init__(self, api, device_info, property_id, translations, coordinator):
+    def __init__(self, api, property_id, coordinator, translations):
         """Initialize the thermostat."""
         super().__init__(coordinator)
         self._api = api
-        self._device_id = device_info["deviceId"]
-        self._device_name = device_info["name"]
+        self._device_id = coordinator.device_id
+        self._device_name = coordinator.device_name
         self._property_id = property_id
         self._attr_translation_key = property_id
         self._attr_has_entity_name = True
@@ -188,9 +187,7 @@ class AppartmeThermostat(CoordinatorEntity, ClimateEntity):
     @property
     def supported_features(self) -> ClimateEntityFeature:
         """Return the supported features."""
-        return (
-            ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.TARGET_TEMPERATURE
-        )
+        return ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.TARGET_TEMPERATURE
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new HVAC mode (No actual change since only HEAT is supported)."""
@@ -211,9 +208,7 @@ class AppartmeThermostat(CoordinatorEntity, ClimateEntity):
             return
 
         try:
-            await self._api.set_device_property_value(
-                self._device_id, "thermostat_mode", value
-            )
+            await self._api.set_device_property_value(self._device_id, "thermostat_mode", value)
             # Optimistically update the preset mode
             self._attr_preset_mode = preset_mode
 
@@ -261,9 +256,7 @@ class AppartmeThermostat(CoordinatorEntity, ClimateEntity):
             return
 
         try:
-            await self._api.set_device_property_value(
-                self._device_id, property_id, temperature
-            )
+            await self._api.set_device_property_value(self._device_id, property_id, temperature)
             # Optimistically update the target temperature
             self._attr_target_temperature = temperature
 

--- a/custom_components/appartme/light.py
+++ b/custom_components/appartme/light.py
@@ -32,7 +32,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             [
                 AppartmeLight(
                     api,
-                    device_info,
                     prop["propertyId"],
                     coordinator,
                 )
@@ -48,12 +47,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class AppartmeLight(CoordinatorEntity, LightEntity):
     """Representation of an Appartme light."""
 
-    def __init__(self, api, device_info, property_id, coordinator):
+    def __init__(self, api, property_id, coordinator):
         """Initialize the light."""
         super().__init__(coordinator)
         self._api = api
-        self._device_id = device_info["deviceId"]
-        self._device_name = device_info["name"]
+        self._device_id = coordinator.device_id
+        self._device_name = coordinator.device_name
         self._property_id = property_id
         self._attr_supported_color_modes = {ColorMode.ONOFF}
         self._attr_translation_key = property_id
@@ -106,9 +105,7 @@ class AppartmeLight(CoordinatorEntity, LightEntity):
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""
         try:
-            await self._api.set_device_property_value(
-                self._device_id, self._property_id, True
-            )
+            await self._api.set_device_property_value(self._device_id, self._property_id, True)
             # Optimistically update the state
             self._attr_is_on = True
             self.async_write_ha_state()
@@ -118,9 +115,7 @@ class AppartmeLight(CoordinatorEntity, LightEntity):
     async def async_turn_off(self, **kwargs):
         """Turn the light off."""
         try:
-            await self._api.set_device_property_value(
-                self._device_id, self._property_id, False
-            )
+            await self._api.set_device_property_value(self._device_id, self._property_id, False)
             # Optimistically update the state
             self._attr_is_on = False
             self.async_write_ha_state()

--- a/custom_components/appartme/sensor.py
+++ b/custom_components/appartme/sensor.py
@@ -65,7 +65,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     [
                         AppartmeEnergySensor(
                             api,
-                            device_info,
                             property_id,
                             coordinator,
                             unit=details["unit"],
@@ -82,7 +81,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             sensors.append(
                 AppartmeEnergySensor(
                     api,
-                    device_info,
                     property_id,
                     coordinator,
                     unit=details["unit"],
@@ -105,7 +103,6 @@ class AppartmeEnergySensor(CoordinatorEntity, SensorEntity):
     def __init__(
         self,
         api,
-        device_info,
         property_id,
         coordinator,
         unit,
@@ -115,8 +112,8 @@ class AppartmeEnergySensor(CoordinatorEntity, SensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._api = api
-        self._device_id = device_info["deviceId"]
-        self._device_name = device_info["name"]
+        self._device_id = coordinator.device_id
+        self._device_name = coordinator.device_name
         self._property_id = property_id
         self._unit = unit
         self._device_class = device_class
@@ -154,9 +151,7 @@ class AppartmeEnergySensor(CoordinatorEntity, SensorEntity):
 
         if self._property_id.startswith("total_"):
             # This is a total sensor; compute the sum of the phase values
-            measurement = self._property_id.split("_")[
-                1
-            ]  # 'current', 'voltage', 'power'
+            measurement = self._property_id.split("_")[1]  # 'current', 'voltage', 'power'
             total_value = 0
             for phase in PHASES:
                 prop_id = f"{phase}_{measurement}"

--- a/custom_components/appartme/switch.py
+++ b/custom_components/appartme/switch.py
@@ -32,7 +32,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             [
                 AppartmeSwitch(
                     api,
-                    device_info,
                     prop["propertyId"],
                     coordinator,
                 )
@@ -52,12 +51,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class AppartmeSwitch(CoordinatorEntity, SwitchEntity):
     """Representation of an Appartme switch."""
 
-    def __init__(self, api, device_info, property_id, coordinator):
+    def __init__(self, api, property_id, coordinator):
         """Initialize the switch."""
         super().__init__(coordinator)
         self._api = api
-        self._device_id = device_info["deviceId"]
-        self._device_name = device_info["name"]
+        self._device_id = coordinator.device_id
+        self._device_name = coordinator.device_name
         self._property_id = property_id
         self._attr_translation_key = property_id
         self._attr_has_entity_name = True
@@ -104,9 +103,7 @@ class AppartmeSwitch(CoordinatorEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
         try:
-            await self._api.set_device_property_value(
-                self._device_id, self._property_id, True
-            )
+            await self._api.set_device_property_value(self._device_id, self._property_id, True)
             # Optimistically update the state after successful API call
             self._attr_is_on = True
             self.async_write_ha_state()
@@ -116,9 +113,7 @@ class AppartmeSwitch(CoordinatorEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
         try:
-            await self._api.set_device_property_value(
-                self._device_id, self._property_id, False
-            )
+            await self._api.set_device_property_value(self._device_id, self._property_id, False)
             # Optimistically update the state after successful API call
             self._attr_is_on = False
             self.async_write_ha_state()

--- a/custom_components/appartme/translations/en.json
+++ b/custom_components/appartme/translations/en.json
@@ -90,6 +90,9 @@
           }
       }
   },
+  "device": {
+      "default_name": "Main Module"
+  },
   "options": {
       "error": {
           "interval_too_short": "Update interval must be at least {min_interval} seconds.",

--- a/custom_components/appartme/translations/pl.json
+++ b/custom_components/appartme/translations/pl.json
@@ -90,6 +90,9 @@
       }
     }
   },
+  "device": {
+    "default_name": "Moduł Mieszkaniowy"
+  },
   "options": {
     "error": {
       "interval_too_short": "Częstotliwość odświeżania musi wynosić co najmniej {min_interval} sekund.",

--- a/custom_components/appartme/valve.py
+++ b/custom_components/appartme/valve.py
@@ -32,7 +32,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             [
                 AppartmeWaterValve(
                     api,
-                    device_info,
                     prop["propertyId"],
                     coordinator,
                 )
@@ -52,12 +51,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class AppartmeWaterValve(CoordinatorEntity, ValveEntity):
     """Representation of an Appartme water valve."""
 
-    def __init__(self, api, device_info, property_id, coordinator):
+    def __init__(self, api, property_id, coordinator):
         """Initialize the valve."""
         super().__init__(coordinator)
         self._api = api
-        self._device_id = device_info["deviceId"]
-        self._device_name = device_info["name"]
+        self._device_id = coordinator.device_id
+        self._device_name = coordinator.device_name
         self._property_id = property_id
         self._attr_translation_key = property_id
         self._attr_has_entity_name = True
@@ -133,9 +132,7 @@ class AppartmeWaterValve(CoordinatorEntity, ValveEntity):
     async def async_open_valve(self, **kwargs):
         """Open the valve."""
         try:
-            await self._api.set_device_property_value(
-                self._device_id, self._property_id, True
-            )
+            await self._api.set_device_property_value(self._device_id, self._property_id, True)
             # Optimistically update the state
             self._attr_is_closed = False
             self.async_write_ha_state()
@@ -145,9 +142,7 @@ class AppartmeWaterValve(CoordinatorEntity, ValveEntity):
     async def async_close_valve(self, **kwargs):
         """Close the valve."""
         try:
-            await self._api.set_device_property_value(
-                self._device_id, self._property_id, False
-            )
+            await self._api.set_device_property_value(self._device_id, self._property_id, False)
             # Optimistically update the state
             self._attr_is_closed = True
             self.async_write_ha_state()


### PR DESCRIPTION
This pull request refactors the Appartme Home Assistant integration to simplify entity initialization and improve device name handling. The main changes involve using the `coordinator` to provide device information to all entity classes, removing redundant `device_info` parameters, and ensuring device names are properly localized using translations. Additionally, some minor code cleanups and translation updates are included.

**Entity Initialization Refactor:**

* All entity classes (`AppartmeThermostat`, `AppartmeLight`, `AppartmeSwitch`, `AppartmeWaterValve`, `AppartmeEnergySensor`) now obtain `device_id` and `device_name` from the `coordinator` instead of directly from `device_info`. This removes the need to pass `device_info` to entity constructors, simplifying entity setup and ensuring consistency. [[1]](diffhunk://#diff-53eed44d0f364566379a094d50ce3b510681128a4fd2583a6681b2a24eca5a0bL45-R47) [[2]](diffhunk://#diff-53eed44d0f364566379a094d50ce3b510681128a4fd2583a6681b2a24eca5a0bL66-R70) [[3]](diffhunk://#diff-a2dba939794189bceb2165466c109257395be889a9f4aab38332db7f5284965bL35) [[4]](diffhunk://#diff-a2dba939794189bceb2165466c109257395be889a9f4aab38332db7f5284965bL51-R55) [[5]](diffhunk://#diff-7b33f042d7954dd5ccf31827275426791ec0713f56fefcbd21e80be6e38b8bd6L68) [[6]](diffhunk://#diff-7b33f042d7954dd5ccf31827275426791ec0713f56fefcbd21e80be6e38b8bd6L85) [[7]](diffhunk://#diff-7b33f042d7954dd5ccf31827275426791ec0713f56fefcbd21e80be6e38b8bd6L108) [[8]](diffhunk://#diff-7b33f042d7954dd5ccf31827275426791ec0713f56fefcbd21e80be6e38b8bd6L118-R116) [[9]](diffhunk://#diff-ea3c024cfbd851b1dfa22a6cc635daa9c97661be3ea06edab1dd06eb6e318b4eL35) [[10]](diffhunk://#diff-ea3c024cfbd851b1dfa22a6cc635daa9c97661be3ea06edab1dd06eb6e318b4eL55-R59) [[11]](diffhunk://#diff-006e44f4ed6b7043050ee310e7978a23779b9e42051a952e40e8de03df718a5bL35) [[12]](diffhunk://#diff-006e44f4ed6b7043050ee310e7978a23779b9e42051a952e40e8de03df718a5bL55-R59)

**Device Name Localization:**

* Device names now default to a localized string (`"Main Module"` or `"Moduł Mieszkaniowy"`) if not provided, using the new translation keys added to `en.json` and `pl.json`. [[1]](diffhunk://#diff-601758a5c7d6722397108da32e4a0eca5c9914772be9247019fc06ce737da27dR118-R128) [[2]](diffhunk://#diff-a2303866922fadb21e95322d81e6ccbc40d2ba38c655d6513bfb8bda2ed7375eR93-R95) [[3]](diffhunk://#diff-73ae6b260e4978d5edb403f0160b8b4873a38ef2eaf34514a3dbd2480c9c38f3R93-R95)

**API Call Simplification:**

* Streamlined API calls in entity methods by removing unnecessary line breaks and directly passing parameters, improving code readability. [[1]](diffhunk://#diff-53eed44d0f364566379a094d50ce3b510681128a4fd2583a6681b2a24eca5a0bL214-R211) [[2]](diffhunk://#diff-53eed44d0f364566379a094d50ce3b510681128a4fd2583a6681b2a24eca5a0bL264-R259) [[3]](diffhunk://#diff-a2dba939794189bceb2165466c109257395be889a9f4aab38332db7f5284965bL109-R108) [[4]](diffhunk://#diff-a2dba939794189bceb2165466c109257395be889a9f4aab38332db7f5284965bL121-R118) [[5]](diffhunk://#diff-ea3c024cfbd851b1dfa22a6cc635daa9c97661be3ea06edab1dd06eb6e318b4eL107-R106) [[6]](diffhunk://#diff-ea3c024cfbd851b1dfa22a6cc635daa9c97661be3ea06edab1dd06eb6e318b4eL119-R116) [[7]](diffhunk://#diff-006e44f4ed6b7043050ee310e7978a23779b9e42051a952e40e8de03df718a5bL136-R135) [[8]](diffhunk://#diff-006e44f4ed6b7043050ee310e7978a23779b9e42051a952e40e8de03df718a5bL148-R145)

**Minor Code Cleanups:**

* Simplified the logic for extracting measurement types in sensors and removed redundant parentheses in feature definitions. [[1]](diffhunk://#diff-7b33f042d7954dd5ccf31827275426791ec0713f56fefcbd21e80be6e38b8bd6L157-R154) [[2]](diffhunk://#diff-53eed44d0f364566379a094d50ce3b510681128a4fd2583a6681b2a24eca5a0bL191-R190)

These changes collectively make the codebase more maintainable, ensure consistent device naming across languages, and reduce boilerplate in entity initialization.